### PR TITLE
Add readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Boutique
+
+[![GitHub package version](https://badgen.net/github/release/ExtensionEngine/boutique)](https://github.com/ExtensionEngine/boutique/releases)
+[![Codacy Badge](https://api.codacy.com/project/badge/Grade/105e3679b14c4b7b9205981734e90424?branch=develop)](https://www.codacy.com/app/ExtensionEngine/boutique?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=ExtensionEngine/boutique&amp;utm_campaign=Badge_Grade)
+[![Known Vulnerabilities](https://snyk.io/test/github/ExtensionEngine/boutique/develop/badge.svg)](https://snyk.io/test/github/ExtensionEngine/boutique)
+[![GitHub license](https://badgen.net/github/license/ExtensionEngine/boutique)](https://github.com/ExtensionEngine/boutique/blob/develop/LICENSE)
+[![js semistandard style](https://badgen.net/badge/code%20style/semistandard/pink)](https://github.com/Flet/semistandard)
+[![Open Source Love](https://badges.frapsoft.com/os/v2/open-source.svg?v=102)](https://github.com/ellerbrock/open-source-badge/)
+
+>Under construction :construction:


### PR DESCRIPTION
Adding initial version of `README.md` with integration badges powered by [badgen.net](https://badgen.net). License badge is currently in _invalid_ state due to missing `LICENSE` file.