### PR TITLE
Convert timestamps to reusable mixin

### DIFF
--- a/server/common/database/migrations/20180403080953-create-user.js
+++ b/server/common/database/migrations/20180403080953-create-user.js
@@ -1,10 +1,12 @@
 'use strict';
 
 const { role } = require('../../../../common/config');
+const { timestamps } = require('../mixins');
 const values = require('lodash/values');
 
 module.exports = {
   up: (queryInterface, Sequelize) => queryInterface.createTable('user', {
+    ...timestamps(Sequelize),
     id: {
       type: Sequelize.INTEGER,
       primaryKey: true,
@@ -33,20 +35,6 @@ module.exports = {
     lastName: {
       type: Sequelize.STRING,
       field: 'last_name'
-    },
-    createdAt: {
-      type: Sequelize.DATE,
-      field: 'created_at',
-      allowNull: false
-    },
-    updatedAt: {
-      type: Sequelize.DATE,
-      field: 'updated_at',
-      allowNull: false
-    },
-    deletedAt: {
-      type: Sequelize.DATE,
-      field: 'deleted_at'
     }
   }),
   down: (queryInterface, Sequelize) => queryInterface.dropTable('user')

--- a/server/common/database/migrations/20180410120848-create-program.js
+++ b/server/common/database/migrations/20180410120848-create-program.js
@@ -1,9 +1,11 @@
 'use strict';
 
+const { timestamps } = require('../mixins');
 const TABLE_NAME = 'program';
 
 module.exports = {
   up: (queryInterface, Sequelize) => queryInterface.createTable(TABLE_NAME, {
+    ...timestamps(Sequelize),
     id: {
       type: Sequelize.INTEGER,
       primaryKey: true,
@@ -12,20 +14,6 @@ module.exports = {
     name: {
       type: Sequelize.STRING(255),
       allowNull: false
-    },
-    createdAt: {
-      type: Sequelize.DATE,
-      field: 'created_at',
-      allowNull: false
-    },
-    updatedAt: {
-      type: Sequelize.DATE,
-      field: 'updated_at',
-      allowNull: false
-    },
-    deletedAt: {
-      type: Sequelize.DATE,
-      field: 'deleted_at'
     }
   }),
   down: (queryInterface) => queryInterface.dropTable(TABLE_NAME)

--- a/server/common/database/migrations/20180411151248-create-enrollment.js
+++ b/server/common/database/migrations/20180411151248-create-enrollment.js
@@ -1,9 +1,11 @@
 'use strict';
 
+const { timestamps } = require('../mixins');
 const TABLE_NAME = 'enrollment';
 
 module.exports = {
   up: (queryInterface, Sequelize) => queryInterface.createTable(TABLE_NAME, {
+    ...timestamps(Sequelize),
     id: {
       type: Sequelize.INTEGER,
       primaryKey: true,
@@ -23,20 +25,6 @@ module.exports = {
       references: { model: 'program', key: 'id' },
       onDelete: 'NO ACTION',
       allowNull: false
-    },
-    createdAt: {
-      type: Sequelize.DATE,
-      field: 'created_at',
-      allowNull: false
-    },
-    updatedAt: {
-      type: Sequelize.DATE,
-      field: 'updated_at',
-      allowNull: false
-    },
-    deletedAt: {
-      type: Sequelize.DATE,
-      field: 'deleted_at'
     }
   }),
   down: (queryInterface, Sequelize) => queryInterface.dropTable(TABLE_NAME)

--- a/server/common/database/migrations/20180905123830-create-content-repo.js
+++ b/server/common/database/migrations/20180905123830-create-content-repo.js
@@ -1,9 +1,11 @@
 'use strict';
 
+const { timestamps } = require('../mixins');
 const TABLE_NAME = 'content_repo';
 
 module.exports = {
   up: (queryInterface, Sequelize) => queryInterface.createTable(TABLE_NAME, {
+    ...timestamps(Sequelize),
     id: {
       type: Sequelize.INTEGER,
       primaryKey: true,
@@ -45,20 +47,6 @@ module.exports = {
       type: Sequelize.DATE,
       field: 'published_at',
       allowNull: false
-    },
-    createdAt: {
-      type: Sequelize.DATE,
-      field: 'created_at',
-      allowNull: false
-    },
-    updatedAt: {
-      type: Sequelize.DATE,
-      field: 'updated_at',
-      allowNull: false
-    },
-    deletedAt: {
-      type: Sequelize.DATE,
-      field: 'deleted_at'
     }
   }),
   down: (queryInterface, Sequelize) => queryInterface.dropTable(TABLE_NAME)

--- a/server/common/database/mixins.js
+++ b/server/common/database/mixins.js
@@ -1,0 +1,18 @@
+'use strict';
+
+exports.timestamps = DataTypes => ({
+  createdAt: {
+    type: DataTypes.DATE,
+    allowNull: false,
+    field: 'created_at'
+  },
+  updatedAt: {
+    type: DataTypes.DATE,
+    allowNull: false,
+    field: 'updated_at'
+  },
+  deletedAt: {
+    type: DataTypes.DATE,
+    field: 'deleted_at'
+  }
+});

--- a/server/content-repo/content-repo.model.js
+++ b/server/content-repo/content-repo.model.js
@@ -1,10 +1,12 @@
 'use strict';
 
 const { Model } = require('sequelize');
+const { timestamps } = require('../common/database/mixins');
 
 class ContentRepo extends Model {
   static fields(DataTypes) {
     return {
+      ...timestamps(DataTypes),
       sourceId: {
         type: DataTypes.INTEGER,
         allowNull: false,
@@ -38,20 +40,6 @@ class ContentRepo extends Model {
         type: DataTypes.DATE,
         allowNull: false,
         field: 'published_at'
-      },
-      createdAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-        field: 'created_at'
-      },
-      updatedAt: {
-        type: DataTypes.DATE,
-        allowNull: false,
-        field: 'updated_at'
-      },
-      deletedAt: {
-        type: DataTypes.DATE,
-        field: 'deleted_at'
       }
     };
   }

--- a/server/enrollment/enrollment.model.js
+++ b/server/enrollment/enrollment.model.js
@@ -1,23 +1,11 @@
 'use strict';
 
 const { Model } = require('sequelize');
+const { timestamps } = require('../common/database/mixins');
 
 class Enrollment extends Model {
   static fields(DataTypes) {
-    return {
-      createdAt: {
-        type: DataTypes.DATE,
-        field: 'created_at'
-      },
-      updatedAt: {
-        type: DataTypes.DATE,
-        field: 'updated_at'
-      },
-      deletedAt: {
-        type: DataTypes.DATE,
-        field: 'deleted_at'
-      }
-    };
+    return timestamps(DataTypes);
   }
 
   static associate({ Program, User }) {

--- a/server/program/program.model.js
+++ b/server/program/program.model.js
@@ -1,26 +1,16 @@
 'use strict';
 
 const { Model } = require('sequelize');
+const { timestamps } = require('../common/database/mixins');
 
 class Program extends Model {
   static fields(DataTypes) {
     return {
+      ...timestamps(DataTypes),
       name: {
         type: DataTypes.STRING,
         allowNull: false,
         validate: { notEmpty: true, len: [2, 255] }
-      },
-      createdAt: {
-        type: DataTypes.DATE,
-        field: 'created_at'
-      },
-      updatedAt: {
-        type: DataTypes.DATE,
-        field: 'updated_at'
-      },
-      deletedAt: {
-        type: DataTypes.DATE,
-        field: 'deleted_at'
       }
     };
   }

--- a/server/user/user.model.js
+++ b/server/user/user.model.js
@@ -3,6 +3,7 @@
 const { auth: config = {} } = require('../config');
 const { Model } = require('sequelize');
 const { role } = require('../../common/config');
+const { timestamps } = require('../common/database/mixins');
 const bcrypt = require('bcrypt');
 const forEach = require('lodash/forEach');
 const jwt = require('jsonwebtoken');
@@ -16,6 +17,7 @@ const values = require('lodash/values');
 class User extends Model {
   static fields(DataTypes) {
     return {
+      ...timestamps(DataTypes),
       email: {
         type: DataTypes.STRING,
         allowNull: false,
@@ -42,18 +44,6 @@ class User extends Model {
       lastName: {
         type: DataTypes.STRING,
         field: 'last_name'
-      },
-      createdAt: {
-        type: DataTypes.DATE,
-        field: 'created_at'
-      },
-      updatedAt: {
-        type: DataTypes.DATE,
-        field: 'updated_at'
-      },
-      deletedAt: {
-        type: DataTypes.DATE,
-        field: 'deleted_at'
       },
       profile: {
         type: DataTypes.VIRTUAL,


### PR DESCRIPTION
Using `timestamps(DataTypes)` helper inside migrations & model definitions in order to decrease code duplication 🎉 