### PR TITLE
Fix text field loses focus on input

### DIFF
--- a/client/common/focustrap.js
+++ b/client/common/focustrap.js
@@ -4,10 +4,6 @@ export const withFocusTrap = (options = {}) => ({
   mounted() {
     this.focusTrap = initFocusTrap(this, options);
   },
-  updated() {
-    if (this.focusTrap) this.focusTrap.deactivate();
-    this.focusTrap = initFocusTrap(this, options);
-  },
   beforeDestroy() {
     this.focusTrap = null;
   }


### PR DESCRIPTION
Text fields loses focus on input because of deactivating focus trap on updated hook.