### PR TITLE
Bundle optimization

### DIFF
--- a/poi.config.js
+++ b/poi.config.js
@@ -25,6 +25,13 @@ const devServer = {
   hotEntries: ['admin', 'student']
 };
 
+const optimization = {
+  splitChunks: {
+    chunks: 'all'
+  },
+  runtimeChunk: true
+};
+
 module.exports = {
   plugins: [
     '@poi/eslint'
@@ -49,6 +56,7 @@ module.exports = {
     config.resolve.extensions.merge(extensions);
   },
   configureWebpack(config) {
+    config.optimization = optimization;
     if (!argv._.includes('--bundle-report')) return;
     config.plugins.push(new BundleAnalyzerPlugin());
   },


### PR DESCRIPTION
Overrides webpack config in order to:
- split single vendor chunk into 3 separate chunks (`vendors~admin.chunk.js`, `vendors~student.chunk.js` & `vendors~admin~student.chunk.js`)
- split single css vendor chunk into `vendors~admin.chunk.css` & `vendors~student.chunk.css`
- add a runtime chunk for each entry (_i.e. separate runtime from bundle_) to enable long term caching