### PR TITLE
Lint everything so that configs are not ignored

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 dist
+node_modules

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "db:reset": "npm run db drop && npm run db create && npm run db migrate",
     "db:seed": "npm run db seed:all",
     "user:add": "node ./server/script/add-user.js",
-    "lint:js": "eslint --ext .js,.vue server client",
+    "lint:js": "eslint --ext .js,.vue .",
     "lint:scss": "stylelint \"client/**/*.vue\" \"client/**/*.scss\"",
     "lint": "npm run lint:js; npm run lint:scss",
     "debug": "nodemon --inspect-brk -r dotenv/config ./server | bunyan",

--- a/server/app.js
+++ b/server/app.js
@@ -29,7 +29,7 @@ app.use(express.static(config.staticFolder));
 app.use(jsend);
 
 // Log http requests
-const isSuccessful = res => res.statusCode <= 400;
+const isSuccessful = res => res.statusCode >= 200 && res.statusCode < 400;
 const format = process.env.NODE_ENV === 'production' ? 'combined' : 'dev';
 app.use(morgan(format, {
   skip: (req, res) => isSuccessful(res),


### PR DESCRIPTION
Per discussion with @vladimyr changing linter to lint everything except dist and node_modules (for now). This will make sure other configs or possibly scripts are also linted.
Also changing the logic of what status code makes response successful. 🔢 