### PR TITLE
Set successful request status to just 2xx range

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -29,7 +29,7 @@ app.use(express.static(config.staticFolder));
 app.use(jsend);
 
 // Log http requests
-const isSuccessful = res => res.statusCode >= 200 && res.statusCode < 400;
+const isSuccessful = res => res.statusCode >= 200 && res.statusCode < 300;
 const format = process.env.NODE_ENV === 'production' ? 'combined' : 'dev';
 app.use(morgan(format, {
   skip: (req, res) => isSuccessful(res),


### PR DESCRIPTION
Per axios: https://github.com/axios/axios/blob/master/lib/defaults.js#L80
and fetch: https://developer.mozilla.org/en-US/docs/Web/API/Response/ok
only 2xx range is valid.