### PR TITLE
Clean output directory plugin

### DIFF
--- a/build/plugins/clean-out-dir.js
+++ b/build/plugins/clean-out-dir.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const CleanWebpackPlugin = require('clean-webpack-plugin');
-
 exports.name = 'clean-out-dir';
 
 exports.apply = (api, opts = {}) => {
@@ -11,6 +9,6 @@ exports.apply = (api, opts = {}) => {
     opts.root = opts.root || api.cwd;
     config
       .plugin('clean-out-dir')
-      .use(CleanWebpackPlugin, [path, opts]);
+      .use(require.resolve('clean-webpack-plugin'), [path, opts]);
   });
 };

--- a/build/plugins/clean-out-dir.js
+++ b/build/plugins/clean-out-dir.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const CleanWebpackPlugin = require('clean-webpack-plugin');
+
+exports.name = 'clean-out-dir';
+
+exports.apply = (api, opts = {}) => {
+  api.hook('createWebpackChain', config => {
+    if (!api.config.output.clean) return;
+    const path = api.resolveOutDir();
+    opts.root = opts.root || api.cwd;
+    config
+      .plugin('clean-out-dir')
+      .use(CleanWebpackPlugin, [path, opts]);
+  });
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -3907,6 +3907,15 @@
         }
       }
     },
+    "clean-webpack-plugin": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/clean-webpack-plugin/-/clean-webpack-plugin-1.0.1.tgz",
+      "integrity": "sha512-gvwfMsqu3HBgTVvaBa1H3AZKO03CHpr5uP92SPIktP3827EovAitwW+1xoqXyTxCuXnLYpMHG5ytS4AoukHDWA==",
+      "dev": true,
+      "requires": {
+        "rimraf": "^2.6.1"
+      }
+    },
     "cli-boxes": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
@@ -6062,7 +6071,7 @@
         },
         "load-json-file": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "dev": true,
           "requires": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@babel/core": "^7.1.2",
     "@poi/plugin-bundle-report": "^12.1.0",
     "@poi/plugin-eslint": "^12.0.0",
+    "clean-webpack-plugin": "^1.0.1",
     "dargs": "^6.0.0",
     "del-cli": "^1.1.0",
     "emoji-strip": "^1.0.1",

--- a/poi.config.js
+++ b/poi.config.js
@@ -26,6 +26,10 @@ module.exports = {
   plugins: [
     '@poi/eslint',
     '@poi/bundle-report',
+    {
+      resolve: require.resolve('./build/plugins/clean-out-dir'),
+      options: { exclude: '.gitkeep' }
+    },
     require.resolve('./build/plugins/html-version-spec')
   ],
   pages: {


### PR DESCRIPTION
- overrides default `CleanOutDir` plugin with `CleanWebpackPlugin` in order to gain additional control (e.g. preventing removal of `.gitkeep` file)