### PR TITLE
Introduce ability to disable all app-wide loggers

### DIFF
--- a/server/common/database/helpers.js
+++ b/server/common/database/helpers.js
@@ -19,7 +19,6 @@ const sql = {
 module.exports = {
   sql,
   getValidator,
-  setLogging,
   wrapAsyncMethods
 };
 
@@ -40,12 +39,6 @@ function getValidator(Model, attribute) {
     return inRange(input.length, min, max) ||
       `"${attribute}" must be between ${min} and ${max} characters long`;
   };
-}
-
-function setLogging(Model, state) {
-  const { options } = Model.sequelize;
-  options.logging = state;
-  return options.logging;
 }
 
 function concat(...args) {

--- a/server/common/logger.js
+++ b/server/common/logger.js
@@ -8,6 +8,7 @@ const isProduction = process.env.NODE_ENV === 'production';
 // NOTE: Copied from bili (by @egoist): https://git.io/fxupU
 const supportsEmoji = process.platform !== 'win32' ||
                       process.env.TERM === 'xterm-256color';
+const noop = Function.prototype;
 
 const Level = getLevels(Logger);
 const loggers = {};
@@ -18,7 +19,8 @@ function createLogger(name, options = {}) {
   if (!loggers[name]) loggers[name] = new Logger({ ...options, name, serializers });
   return loggers[name];
 }
-Object.assign(createLogger, Logger, { createLogger, Level });
+const disable = () => (Logger.prototype.addStream = noop);
+Object.assign(createLogger, Logger, { createLogger, disable, Level });
 
 module.exports = createLogger;
 

--- a/server/script/add-user.js
+++ b/server/script/add-user.js
@@ -1,14 +1,15 @@
 'use strict';
 
-const { getValidator, setLogging } = require('../common/database/helpers');
+// Disable app-wide logging.
+require('../common/logger').disable();
+
+const { getValidator } = require('../common/database/helpers');
 const { prompt } = require('inquirer');
 const { role } = require('../../common/config');
 const { User } = require('../common/database');
 const humanize = require('humanize-string');
 const isEmail = require('is-email-like');
 const map = require('lodash/map');
-
-setLogging(User, false);
 
 const questions = [{
   type: 'input',

--- a/server/script/sequelize.js
+++ b/server/script/sequelize.js
@@ -20,6 +20,9 @@ if (!config) {
   process.exit(1);
 }
 
+// Disable query logging.
+setLogging(config, false);
+
 const argv = minimist(process.argv.slice(2));
 process.argv.length = 2;
 
@@ -33,6 +36,12 @@ process.argv.push(...dargs(options));
 
 // Make it rain!
 require('sequelize-cli/lib/sequelize');
+
+function setLogging({ config: configPath }, state) {
+  const config = require(configPath);
+  config.logging = state;
+  return config;
+}
 
 function getArgs(argv) {
   let [cmd, ...args] = argv._;


### PR DESCRIPTION
This PR introduce global logger `#disable` to prevent (sequelize query and other service) logging inside server scripts.