### PR TITLE
Check for richtext and return plain text instead

### DIFF
--- a/server/user/datasheet.js
+++ b/server/user/datasheet.js
@@ -7,7 +7,8 @@ const Worksheet = require('exceljs/dist/es5/doc/worksheet');
 
 const isCsv = file => file.mimetype === 'text/csv';
 const isString = arg => typeof arg === 'string';
-const parseCell = cell => cell.isHyperlink ? cell.value.text : cell.value;
+const parseCell = cell => cell.isHyperlink ? parseCellText(cell.value.text) : cell.value;
+const parseCellText = cellText => cellText.richText ? cellText.richText[0].text : cellText;
 
 Object.assign(Workbook.prototype, {
   addSheet(sheet) {

--- a/server/user/datasheet.js
+++ b/server/user/datasheet.js
@@ -8,7 +8,9 @@ const Worksheet = require('exceljs/dist/es5/doc/worksheet');
 const isCsv = file => file.mimetype === 'text/csv';
 const isString = arg => typeof arg === 'string';
 const parseCell = cell => cell.isHyperlink ? parseCellText(cell.value.text) : cell.value;
-const parseCellText = cellText => cellText.richText ? cellText.richText[0].text : cellText;
+const parseCellText = cellText => cellText.richText
+  ? cellText.richText.reduce((acc, it) => `${acc}${it.text}`, '')
+  : cellText;
 
 Object.assign(Workbook.prototype, {
   addSheet(sheet) {


### PR DESCRIPTION
### This PR
- [x] Parses rich text from sheets - extract only plain text from from formatted cells


### Why
If the values in the cells are formatted in any way (fontsize, bold, color, etc), the value from that field will be `richtext` array. 

You wouldn't be able to upload a sheet like this: 
![image](https://user-images.githubusercontent.com/1560102/106892223-0c52cc80-66ec-11eb-8728-9b56329bb9b5.png)

### Ping
@mcapeta @kronicker
